### PR TITLE
app.destroySearchbar is removed in Framework7 v1.0.3

### DIFF
--- a/app/components/f7-search-bar.js
+++ b/app/components/f7-search-bar.js
@@ -19,10 +19,6 @@ export default Ember.Component.extend({
     this.get('f7').initSearchbar(this.$());
   },
 
-  willDestroyElement: function() {
-    this.get('f7').destroySearchbar(this.$());
-  },
-
   onQueryChanged: function() {
     this.sendAction('action', this.get('query'));
   }.observes('query')


### PR DESCRIPTION
See https://github.com/nolimits4web/Framework7/blob/master/CHANGELOG.md
